### PR TITLE
Create main.yml

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,0 +1,717 @@
+travis_fold:start:worker_info
+[0K[33;1mWorker information[0m
+hostname: f4c42282-3701-409e-8ac9-da7cd8782ddd@1.worker-org-676f4fdd9b-pb25b.gce-production-2
+version: v6.2.8 https://github.com/travis-ci/worker/tree/6d3048d96b26562be21fa1a8b8144f4c4cecd083
+instance: travis-job-4fab389b-f96a-4057-8730-5eea861a89c5 travis-ci-sardonyx-xenial-1553530528-f909ac5 (via amqp)
+startup: 6.203221808s
+travis_fold:end:worker_info
+[0Ktravis_time:start:0c642b00
+[0Ktravis_time:end:0c642b00:start=1582602377733721654,finish=1582602377887978682,duration=154257028,event=no_world_writable_dirs
+[0Ktravis_time:start:061f25f4
+[0Ktravis_time:end:061f25f4:start=1582602377891558286,finish=1582602377899751147,duration=8192861,event=agent
+[0Ktravis_time:start:2c4c2fa9
+[0Ktravis_time:end:2c4c2fa9:start=1582602377902946565,finish=1582602377905210699,duration=2264134,event=check_unsupported
+[0Ktravis_time:start:0b9d12ea
+[0Ktravis_fold:start:system_info
+[0K[33;1mBuild system information[0m
+Build language: node_js
+Build group: stable
+Build dist: xenial
+Build id: 654724633
+Job id: 654724634
+Runtime kernel version: 4.15.0-1028-gcp
+travis-build version: ad8144f58
+[34m[1mBuild image provisioning date and time[0m
+Mon Mar 25 16:43:24 UTC 2019
+[34m[1mOperating System Details[0m
+Distributor ID:	Ubuntu
+Description:	Ubuntu 16.04.6 LTS
+Release:	16.04
+Codename:	xenial
+[34m[1mSystemd Version[0m
+systemd 229
+[34m[1mCookbooks Version[0m
+42e42e4 https://github.com/travis-ci/travis-cookbooks/tree/42e42e4
+[34m[1mgit version[0m
+git version 2.21.0
+[34m[1mbash version[0m
+GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
+[34m[1mgcc version[0m
+gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
+[34m[1mdocker version[0m
+Client:
+ Version:           18.06.0-ce
+ API version:       1.38
+ Go version:        go1.10.3
+ Git commit:        0ffa825
+ Built:             Wed Jul 18 19:11:02 2018
+ OS/Arch:           linux/amd64
+ Experimental:      false
+
+Server:
+ Engine:
+  Version:          18.06.0-ce
+  API version:      1.38 (minimum version 1.12)
+  Go version:       go1.10.3
+  Git commit:       0ffa825
+  Built:            Wed Jul 18 19:09:05 2018
+  OS/Arch:          linux/amd64
+  Experimental:     false
+[34m[1mclang version[0m
+clang version 7.0.0 (tags/RELEASE_700/final)
+[34m[1mjq version[0m
+jq-1.5
+[34m[1mbats version[0m
+Bats 0.4.0
+[34m[1mshellcheck version[0m
+0.6.0
+[34m[1mshfmt version[0m
+v2.6.3
+[34m[1mccache version[0m
+3.2.4
+[34m[1mcmake version[0m
+cmake version 3.12.4
+[34m[1mheroku version[0m
+heroku/7.22.7 linux-x64 node-v11.10.1
+[34m[1mimagemagick version[0m
+Version: ImageMagick 6.8.9-9 Q16 x86_64 2018-09-28 http://www.imagemagick.org
+[34m[1mmd5deep version[0m
+4.4
+[34m[1mmercurial version[0m
+version 4.8
+[34m[1mmysql version[0m
+mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper
+[34m[1mopenssl version[0m
+OpenSSL 1.0.2g  1 Mar 2016
+[34m[1mpacker version[0m
+1.3.3
+[34m[1mpostgresql client version[0m
+psql (PostgreSQL) 10.7 (Ubuntu 10.7-1.pgdg16.04+1)
+[34m[1mragel version[0m
+Ragel State Machine Compiler version 6.8 Feb 2013
+[34m[1msudo version[0m
+1.8.16
+[34m[1mgzip version[0m
+gzip 1.6
+[34m[1mzip version[0m
+Zip 3.0
+[34m[1mvim version[0m
+VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:44:48)
+[34m[1miptables version[0m
+iptables v1.6.0
+[34m[1mcurl version[0m
+curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
+[34m[1mwget version[0m
+GNU Wget 1.17.1 built on linux-gnu.
+[34m[1mrsync version[0m
+rsync  version 3.1.1  protocol version 31
+[34m[1mgimme version[0m
+v1.5.3
+[34m[1mnvm version[0m
+0.34.0
+[34m[1mperlbrew version[0m
+/home/travis/perl5/perlbrew/bin/perlbrew  - App::perlbrew/0.86
+[34m[1mphpenv version[0m
+rbenv 1.1.2
+[34m[1mrvm version[0m
+rvm 1.29.7 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
+[34m[1mdefault ruby version[0m
+ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
+[34m[1mCouchDB version[0m
+couchdb 1.6.1
+[34m[1mElasticSearch version[0m
+5.5.0
+[34m[1mInstalled Firefox version[0m
+firefox 63.0.1
+[34m[1mMongoDB version[0m
+MongoDB 4.0.7
+[34m[1mPhantomJS version[0m
+2.1.1
+[34m[1mPre-installed PostgreSQL versions[0m
+9.4.21
+9.5.16
+9.6.12
+[34m[1mRedis version[0m
+redis-server 5.0.4
+[34m[1mPre-installed Go versions[0m
+1.11.1
+[34m[1mmvn version[0m
+Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z)
+[34m[1mgradle version[0m
+Gradle 4.10.2!
+[34m[1mlein version[0m
+Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM
+[34m[1mPre-installed Node.js versions[0m
+v10.15.3
+v11.0.0
+v4.9.1
+v6.17.0
+v8.12.0
+v8.15.1
+v8.9
+[34m[1mphpenv versions[0m
+  system
+  5.6
+  5.6.40
+  7.1
+  7.1.27
+  7.2
+* 7.2.15 (set by /home/travis/.phpenv/version)
+  hhvm
+  hhvm-stable
+[34m[1mcomposer --version[0m
+Composer version 1.8.4 2019-02-11 10:52:10
+[34m[1mPre-installed Ruby versions[0m
+ruby-2.3.8
+ruby-2.4.5
+ruby-2.5.3
+travis_fold:end:system_info
+[0K
+travis_time:end:0b9d12ea:start=1582602377908239175,finish=1582602377916722008,duration=8482833,event=show_system_info
+[0Ktravis_time:start:32ccfb00
+[0Ktravis_time:end:32ccfb00:start=1582602377920110024,finish=1582602377932191439,duration=12081415,event=rm_riak_source
+[0Ktravis_time:start:0605c6d8
+[0Ktravis_time:end:0605c6d8:start=1582602377937473008,finish=1582602377944632400,duration=7159392,event=fix_rwky_redis
+[0Ktravis_time:start:0af9f344
+[0Ktravis_time:end:0af9f344:start=1582602377947973468,finish=1582602378248944212,duration=300970744,event=wait_for_network
+[0Ktravis_time:start:0511f09e
+[0Ktravis_time:end:0511f09e:start=1582602378252254897,finish=1582602378459575767,duration=207320870,event=update_apt_keys
+[0Ktravis_time:start:0c3a71d2
+[0Ktravis_time:end:0c3a71d2:start=1582602378462460967,finish=1582602378517080198,duration=54619231,event=fix_hhvm_source
+[0Ktravis_time:start:2437fd56
+[0Ktravis_time:end:2437fd56:start=1582602378520583698,finish=1582602378523450227,duration=2866529,event=update_mongo_arch
+[0Ktravis_time:start:07f27c98
+[0Ktravis_time:end:07f27c98:start=1582602378526342780,finish=1582602378567452996,duration=41110216,event=fix_sudo_enabled_trusty
+[0Ktravis_time:start:1049cc5d
+[0Ktravis_time:end:1049cc5d:start=1582602378570671255,finish=1582602378572965507,duration=2294252,event=update_glibc
+[0Ktravis_time:start:15934c60
+[0Ktravis_time:end:15934c60:start=1582602378575884738,finish=1582602378583714176,duration=7829438,event=clean_up_path
+[0Ktravis_time:start:10f81d70
+[0Ktravis_time:end:10f81d70:start=1582602378586627474,finish=1582602378594357444,duration=7729970,event=fix_resolv_conf
+[0Ktravis_time:start:16867734
+[0Ktravis_time:end:16867734:start=1582602378597227444,finish=1582602378605839434,duration=8611990,event=fix_etc_hosts
+[0Ktravis_time:start:2883b6fe
+[0Ktravis_time:end:2883b6fe:start=1582602378608706481,finish=1582602378618332200,duration=9625719,event=fix_mvn_settings_xml
+[0Ktravis_time:start:0202e1ce
+[0Ktravis_time:end:0202e1ce:start=1582602378621366943,finish=1582602378630533960,duration=9167017,event=no_ipv6_localhost
+[0Ktravis_time:start:0b171282
+[0Ktravis_time:end:0b171282:start=1582602378633505944,finish=1582602378635769112,duration=2263168,event=fix_etc_mavenrc
+[0Ktravis_time:start:0c523e78
+[0Ktravis_time:end:0c523e78:start=1582602378638594598,finish=1582602378641494951,duration=2900353,event=fix_wwdr_certificate
+[0Ktravis_time:start:0de5c3a3
+[0Ktravis_time:end:0de5c3a3:start=1582602378644398844,finish=1582602378667133538,duration=22734694,event=put_localhost_first
+[0Ktravis_time:start:07abc884
+[0Ktravis_time:end:07abc884:start=1582602378670099492,finish=1582602378673182050,duration=3082558,event=home_paths
+[0Ktravis_time:start:224fa62e
+[0Ktravis_time:end:224fa62e:start=1582602378676272690,finish=1582602378689527103,duration=13254413,event=disable_initramfs
+[0Ktravis_time:start:1af9da20
+[0Ktravis_time:end:1af9da20:start=1582602378692674433,finish=1582602379005631987,duration=312957554,event=disable_ssh_roaming
+[0Ktravis_time:start:03487cc8
+[0Ktravis_time:end:03487cc8:start=1582602379008600820,finish=1582602379010698179,duration=2097359,event=debug_tools
+[0Ktravis_time:start:0f2f162e
+[0Ktravis_time:end:0f2f162e:start=1582602379013526764,finish=1582602379016670409,duration=3143645,event=uninstall_oclint
+[0Ktravis_time:start:18cda970
+[0Ktravis_time:end:18cda970:start=1582602379019814239,finish=1582602379022720070,duration=2905831,event=rvm_use
+[0Ktravis_time:start:05271bd0
+[0Ktravis_time:end:05271bd0:start=1582602379025646096,finish=1582602379033399573,duration=7753477,event=rm_etc_boto_cfg
+[0Ktravis_time:start:04b87604
+[0Ktravis_time:end:04b87604:start=1582602379036553108,finish=1582602379039525192,duration=2972084,event=rm_oraclejdk8_symlink
+[0Ktravis_time:start:047a9249
+[0Ktravis_time:end:047a9249:start=1582602379042461991,finish=1582602379157804884,duration=115342893,event=enable_i386
+[0Ktravis_time:start:0f758e7e
+[0Ktravis_time:end:0f758e7e:start=1582602379160876391,finish=1582602379167337155,duration=6460764,event=update_rubygems
+[0Ktravis_time:start:23b59e22
+[0Ktravis_time:end:23b59e22:start=1582602379170313746,finish=1582602379990692515,duration=820378769,event=ensure_path_components
+[0Ktravis_time:start:06f9041a
+[0Ktravis_time:end:06f9041a:start=1582602379993993894,finish=1582602379996231026,duration=2237132,event=redefine_curl
+[0Ktravis_time:start:0fdd2884
+[0Ktravis_time:end:0fdd2884:start=1582602379999080755,finish=1582602380001314659,duration=2233904,event=nonblock_pipe
+[0Ktravis_time:start:07ce13e0
+[0Ktravis_time:end:07ce13e0:start=1582602380004230784,finish=1582602386036542583,duration=6032311799,event=apt_get_update
+[0Ktravis_time:start:090b03c7
+[0Ktravis_time:end:090b03c7:start=1582602386040202715,finish=1582602386042472669,duration=2269954,event=deprecate_xcode_64
+[0Ktravis_time:start:25910850
+[0Ktravis_time:end:25910850:start=1582602386045282804,finish=1582602388606270491,duration=2560987687,event=update_heroku
+[0Ktravis_time:start:1acb3f26
+[0Ktravis_time:end:1acb3f26:start=1582602388609774837,finish=1582602388612100541,duration=2325704,event=shell_session_update
+[0Ktravis_time:start:002a224a
+[0Ktravis_fold:start:docker_mtu
+[0Ktravis_fold:end:docker_mtu
+[0Ktravis_time:end:002a224a:start=1582602388615299458,finish=1582602390873720502,duration=2258421044,event=set_docker_mtu
+[0Ktravis_time:start:11040027
+[0Ktravis_fold:start:resolvconf
+[0Ktravis_fold:end:resolvconf
+[0Ktravis_time:end:11040027:start=1582602390879618111,finish=1582602390950635829,duration=71017718,event=resolvconf
+[0Ktravis_time:start:0ac5f51c
+[0Ktravis_time:end:0ac5f51c:start=1582602390955046230,finish=1582602391114151634,duration=159105404,event=maven_central_mirror
+[0Ktravis_time:start:01a828c7
+[0Ktravis_time:end:01a828c7:start=1582602391117480449,finish=1582602391224590480,duration=107110031,event=maven_https
+[0Ktravis_time:start:162c9e8b
+[0Ktravis_time:end:162c9e8b:start=1582602391228807337,finish=1582602391231199258,duration=2391921,event=fix_ps4
+[0Ktravis_time:start:2fc1074c
+[0K
+travis_fold:start:git.checkout
+[0Ktravis_time:start:3267c9b9
+[0K$ git clone --depth=50 --branch=typescript https://github.com/jhlywa/chess.js.git jhlywa/chess.js
+Cloning into 'jhlywa/chess.js'...
+remote: Enumerating objects: 357, done.[K
+remote: Counting objects:   0% (1/357)[K
+remote: Counting objects:   1% (4/357)[K
+remote: Counting objects:   2% (8/357)[K
+remote: Counting objects:   3% (11/357)[K
+remote: Counting objects:   4% (15/357)[K
+remote: Counting objects:   5% (18/357)[K
+remote: Counting objects:   6% (22/357)[K
+remote: Counting objects:   7% (25/357)[K
+remote: Counting objects:   8% (29/357)[K
+remote: Counting objects:   9% (33/357)[K
+remote: Counting objects:  10% (36/357)[K
+remote: Counting objects:  11% (40/357)[K
+remote: Counting objects:  12% (43/357)[K
+remote: Counting objects:  13% (47/357)[K
+remote: Counting objects:  14% (50/357)[K
+remote: Counting objects:  15% (54/357)[K
+remote: Counting objects:  16% (58/357)[K
+remote: Counting objects:  17% (61/357)[K
+remote: Counting objects:  18% (65/357)[K
+remote: Counting objects:  19% (68/357)[K
+remote: Counting objects:  20% (72/357)[K
+remote: Counting objects:  21% (75/357)[K
+remote: Counting objects:  22% (79/357)[K
+remote: Counting objects:  23% (83/357)[K
+remote: Counting objects:  24% (86/357)[K
+remote: Counting objects:  25% (90/357)[K
+remote: Counting objects:  26% (93/357)[K
+remote: Counting objects:  27% (97/357)[K
+remote: Counting objects:  28% (100/357)[K
+remote: Counting objects:  29% (104/357)[K
+remote: Counting objects:  30% (108/357)[K
+remote: Counting objects:  31% (111/357)[K
+remote: Counting objects:  32% (115/357)[K
+remote: Counting objects:  33% (118/357)[K
+remote: Counting objects:  34% (122/357)[K
+remote: Counting objects:  35% (125/357)[K
+remote: Counting objects:  36% (129/357)[K
+remote: Counting objects:  37% (133/357)[K
+remote: Counting objects:  38% (136/357)[K
+remote: Counting objects:  39% (140/357)[K
+remote: Counting objects:  40% (143/357)[K
+remote: Counting objects:  41% (147/357)[K
+remote: Counting objects:  42% (150/357)[K
+remote: Counting objects:  43% (154/357)[K
+remote: Counting objects:  44% (158/357)[K
+remote: Counting objects:  45% (161/357)[K
+remote: Counting objects:  46% (165/357)[K
+remote: Counting objects:  47% (168/357)[K
+remote: Counting objects:  48% (172/357)[K
+remote: Counting objects:  49% (175/357)[K
+remote: Counting objects:  50% (179/357)[K
+remote: Counting objects:  51% (183/357)[K
+remote: Counting objects:  52% (186/357)[K
+remote: Counting objects:  53% (190/357)[K
+remote: Counting objects:  54% (193/357)[K
+remote: Counting objects:  55% (197/357)[K
+remote: Counting objects:  56% (200/357)[K
+remote: Counting objects:  57% (204/357)[K
+remote: Counting objects:  58% (208/357)[K
+remote: Counting objects:  59% (211/357)[K
+remote: Counting objects:  60% (215/357)[K
+remote: Counting objects:  61% (218/357)[K
+remote: Counting objects:  62% (222/357)[K
+remote: Counting objects:  63% (225/357)[K
+remote: Counting objects:  64% (229/357)[K
+remote: Counting objects:  65% (233/357)[K
+remote: Counting objects:  66% (236/357)[K
+remote: Counting objects:  67% (240/357)[K
+remote: Counting objects:  68% (243/357)[K
+remote: Counting objects:  69% (247/357)[K
+remote: Counting objects:  70% (250/357)[K
+remote: Counting objects:  71% (254/357)[K
+remote: Counting objects:  72% (258/357)[K
+remote: Counting objects:  73% (261/357)[K
+remote: Counting objects:  74% (265/357)[K
+remote: Counting objects:  75% (268/357)[K
+remote: Counting objects:  76% (272/357)[K
+remote: Counting objects:  77% (275/357)[K
+remote: Counting objects:  78% (279/357)[K
+remote: Counting objects:  79% (283/357)[K
+remote: Counting objects:  80% (286/357)[K
+remote: Counting objects:  81% (290/357)[K
+remote: Counting objects:  82% (293/357)[K
+remote: Counting objects:  83% (297/357)[K
+remote: Counting objects:  84% (300/357)[K
+remote: Counting objects:  85% (304/357)[K
+remote: Counting objects:  86% (308/357)[K
+remote: Counting objects:  87% (311/357)[K
+remote: Counting objects:  88% (315/357)[K
+remote: Counting objects:  89% (318/357)[K
+remote: Counting objects:  90% (322/357)[K
+remote: Counting objects:  91% (325/357)[K
+remote: Counting objects:  92% (329/357)[K
+remote: Counting objects:  93% (333/357)[K
+remote: Counting objects:  94% (336/357)[K
+remote: Counting objects:  95% (340/357)[K
+remote: Counting objects:  96% (343/357)[K
+remote: Counting objects:  97% (347/357)[K
+remote: Counting objects:  98% (350/357)[K
+remote: Counting objects:  99% (354/357)[K
+remote: Counting objects: 100% (357/357)[K
+remote: Counting objects: 100% (357/357), done.[K
+remote: Compressing objects:   0% (1/166)[K
+remote: Compressing objects:   1% (2/166)[K
+remote: Compressing objects:   2% (4/166)[K
+remote: Compressing objects:   3% (5/166)[K
+remote: Compressing objects:   4% (7/166)[K
+remote: Compressing objects:   5% (9/166)[K
+remote: Compressing objects:   6% (10/166)[K
+remote: Compressing objects:   7% (12/166)[K
+remote: Compressing objects:   8% (14/166)[K
+remote: Compressing objects:   9% (15/166)[K
+remote: Compressing objects:  10% (17/166)[K
+remote: Compressing objects:  11% (19/166)[K
+remote: Compressing objects:  12% (20/166)[K
+remote: Compressing objects:  13% (22/166)[K
+remote: Compressing objects:  14% (24/166)[K
+remote: Compressing objects:  15% (25/166)[K
+remote: Compressing objects:  16% (27/166)[K
+remote: Compressing objects:  17% (29/166)[K
+remote: Compressing objects:  18% (30/166)[K
+remote: Compressing objects:  19% (32/166)[K
+remote: Compressing objects:  20% (34/166)[K
+remote: Compressing objects:  21% (35/166)[K
+remote: Compressing objects:  22% (37/166)[K
+remote: Compressing objects:  23% (39/166)[K
+remote: Compressing objects:  24% (40/166)[K
+remote: Compressing objects:  25% (42/166)[K
+remote: Compressing objects:  26% (44/166)[K
+remote: Compressing objects:  27% (45/166)[K
+remote: Compressing objects:  28% (47/166)[K
+remote: Compressing objects:  29% (49/166)[K
+remote: Compressing objects:  30% (50/166)[K
+remote: Compressing objects:  31% (52/166)[K
+remote: Compressing objects:  32% (54/166)[K
+remote: Compressing objects:  33% (55/166)[K
+remote: Compressing objects:  34% (57/166)[K
+remote: Compressing objects:  35% (59/166)[K
+remote: Compressing objects:  36% (60/166)[K
+remote: Compressing objects:  37% (62/166)[K
+remote: Compressing objects:  38% (64/166)[K
+remote: Compressing objects:  39% (65/166)[K
+remote: Compressing objects:  40% (67/166)[K
+remote: Compressing objects:  41% (69/166)[K
+remote: Compressing objects:  42% (70/166)[K
+remote: Compressing objects:  43% (72/166)[K
+remote: Compressing objects:  44% (74/166)[K
+remote: Compressing objects:  45% (75/166)[K
+remote: Compressing objects:  46% (77/166)[K
+remote: Compressing objects:  47% (79/166)[K
+remote: Compressing objects:  48% (80/166)[K
+remote: Compressing objects:  49% (82/166)[K
+remote: Compressing objects:  50% (83/166)[K
+remote: Compressing objects:  51% (85/166)[K
+remote: Compressing objects:  52% (87/166)[K
+remote: Compressing objects:  53% (88/166)[K
+remote: Compressing objects:  54% (90/166)[K
+remote: Compressing objects:  55% (92/166)[K
+remote: Compressing objects:  56% (93/166)[K
+remote: Compressing objects:  57% (95/166)[K
+remote: Compressing objects:  58% (97/166)[K
+remote: Compressing objects:  59% (98/166)[K
+remote: Compressing objects:  60% (100/166)[K
+remote: Compressing objects:  61% (102/166)[K
+remote: Compressing objects:  62% (103/166)[K
+remote: Compressing objects:  63% (105/166)[K
+remote: Compressing objects:  64% (107/166)[K
+remote: Compressing objects:  65% (108/166)[K
+remote: Compressing objects:  66% (110/166)[K
+remote: Compressing objects:  67% (112/166)[K
+remote: Compressing objects:  68% (113/166)[K
+remote: Compressing objects:  69% (115/166)[K
+remote: Compressing objects:  70% (117/166)[K
+remote: Compressing objects:  71% (118/166)[K
+remote: Compressing objects:  72% (120/166)[K
+remote: Compressing objects:  73% (122/166)[K
+remote: Compressing objects:  74% (123/166)[K
+remote: Compressing objects:  75% (125/166)[K
+remote: Compressing objects:  76% (127/166)[K
+remote: Compressing objects:  77% (128/166)[K
+remote: Compressing objects:  78% (130/166)[K
+remote: Compressing objects:  79% (132/166)[K
+remote: Compressing objects:  80% (133/166)[K
+remote: Compressing objects:  81% (135/166)[K
+remote: Compressing objects:  82% (137/166)[K
+remote: Compressing objects:  83% (138/166)[K
+remote: Compressing objects:  84% (140/166)[K
+remote: Compressing objects:  85% (142/166)[K
+remote: Compressing objects:  86% (143/166)[K
+remote: Compressing objects:  87% (145/166)[K
+remote: Compressing objects:  88% (147/166)[K
+remote: Compressing objects:  89% (148/166)[K
+remote: Compressing objects:  90% (150/166)[K
+remote: Compressing objects:  91% (152/166)[K
+remote: Compressing objects:  92% (153/166)[K
+remote: Compressing objects:  93% (155/166)[K
+remote: Compressing objects:  94% (157/166)[K
+remote: Compressing objects:  95% (158/166)[K
+remote: Compressing objects:  96% (160/166)[K
+remote: Compressing objects:  97% (162/166)[K
+remote: Compressing objects:  98% (163/166)[K
+remote: Compressing objects:  99% (165/166)[K
+remote: Compressing objects: 100% (166/166)[K
+remote: Compressing objects: 100% (166/166), done.[K
+Receiving objects:   0% (1/357)   
+Receiving objects:   1% (4/357)   
+Receiving objects:   2% (8/357)   
+Receiving objects:   3% (11/357)   
+Receiving objects:   4% (15/357)   
+Receiving objects:   5% (18/357)   
+Receiving objects:   6% (22/357)   
+Receiving objects:   7% (25/357)   
+Receiving objects:   8% (29/357)   
+Receiving objects:   9% (33/357)   
+Receiving objects:  10% (36/357)   
+Receiving objects:  11% (40/357)   
+Receiving objects:  12% (43/357)   
+Receiving objects:  13% (47/357)   
+Receiving objects:  14% (50/357)   
+Receiving objects:  15% (54/357)   
+Receiving objects:  16% (58/357)   
+Receiving objects:  17% (61/357)   
+Receiving objects:  18% (65/357)   
+Receiving objects:  19% (68/357)   
+Receiving objects:  20% (72/357)   
+Receiving objects:  21% (75/357)   
+Receiving objects:  22% (79/357)   
+Receiving objects:  23% (83/357)   
+Receiving objects:  24% (86/357)   
+Receiving objects:  25% (90/357)   
+Receiving objects:  26% (93/357)   
+Receiving objects:  27% (97/357)   
+Receiving objects:  28% (100/357)   
+Receiving objects:  29% (104/357)   
+Receiving objects:  30% (108/357)   
+Receiving objects:  31% (111/357)   
+Receiving objects:  32% (115/357)   
+Receiving objects:  33% (118/357)   
+Receiving objects:  34% (122/357)   
+Receiving objects:  35% (125/357)   
+Receiving objects:  36% (129/357)   
+Receiving objects:  37% (133/357)   
+Receiving objects:  38% (136/357)   
+Receiving objects:  39% (140/357)   
+Receiving objects:  40% (143/357)   
+Receiving objects:  41% (147/357)   
+Receiving objects:  42% (150/357)   
+Receiving objects:  43% (154/357)   
+Receiving objects:  44% (158/357)   
+Receiving objects:  45% (161/357)   
+Receiving objects:  46% (165/357)   
+Receiving objects:  47% (168/357)   
+Receiving objects:  48% (172/357)   
+Receiving objects:  49% (175/357)   
+Receiving objects:  50% (179/357)   
+Receiving objects:  51% (183/357)   
+Receiving objects:  52% (186/357)   
+Receiving objects:  53% (190/357)   
+Receiving objects:  54% (193/357)   
+Receiving objects:  55% (197/357)   
+Receiving objects:  56% (200/357)   
+Receiving objects:  57% (204/357)   
+Receiving objects:  58% (208/357)   
+Receiving objects:  59% (211/357)   
+Receiving objects:  60% (215/357)   
+Receiving objects:  61% (218/357)   
+Receiving objects:  62% (222/357)   
+Receiving objects:  63% (225/357)   
+Receiving objects:  64% (229/357)   
+Receiving objects:  65% (233/357)   
+Receiving objects:  66% (236/357)   
+Receiving objects:  67% (240/357)   
+Receiving objects:  68% (243/357)   
+Receiving objects:  69% (247/357)   
+Receiving objects:  70% (250/357)   
+Receiving objects:  71% (254/357)   
+Receiving objects:  72% (258/357)   
+Receiving objects:  73% (261/357)   
+Receiving objects:  74% (265/357)   
+Receiving objects:  75% (268/357)   
+Receiving objects:  76% (272/357)   
+Receiving objects:  77% (275/357)   
+Receiving objects:  78% (279/357)   
+Receiving objects:  79% (283/357)   
+Receiving objects:  80% (286/357)   
+Receiving objects:  81% (290/357)   
+remote: Total 357 (delta 192), reused 319 (delta 157), pack-reused 0[K
+Receiving objects:  82% (293/357)   
+Receiving objects:  83% (297/357)   
+Receiving objects:  84% (300/357)   
+Receiving objects:  85% (304/357)   
+Receiving objects:  86% (308/357)   
+Receiving objects:  87% (311/357)   
+Receiving objects:  88% (315/357)   
+Receiving objects:  89% (318/357)   
+Receiving objects:  90% (322/357)   
+Receiving objects:  91% (325/357)   
+Receiving objects:  92% (329/357)   
+Receiving objects:  93% (333/357)   
+Receiving objects:  94% (336/357)   
+Receiving objects:  95% (340/357)   
+Receiving objects:  96% (343/357)   
+Receiving objects:  97% (347/357)   
+Receiving objects:  98% (350/357)   
+Receiving objects:  99% (354/357)   
+Receiving objects: 100% (357/357)   
+Receiving objects: 100% (357/357), 232.81 KiB | 7.05 MiB/s, done.
+Resolving deltas:   0% (0/192)   
+Resolving deltas:   1% (2/192)   
+Resolving deltas:   2% (4/192)   
+Resolving deltas:   6% (12/192)   
+Resolving deltas:  10% (21/192)   
+Resolving deltas:  17% (34/192)   
+Resolving deltas:  18% (35/192)   
+Resolving deltas:  26% (50/192)   
+Resolving deltas:  39% (76/192)   
+Resolving deltas:  40% (78/192)   
+Resolving deltas:  41% (79/192)   
+Resolving deltas:  52% (100/192)   
+Resolving deltas:  57% (110/192)   
+Resolving deltas:  75% (144/192)   
+Resolving deltas:  82% (158/192)   
+Resolving deltas:  95% (184/192)   
+Resolving deltas: 100% (192/192)   
+Resolving deltas: 100% (192/192), done.
+travis_time:end:3267c9b9:start=1582602391238252383,finish=1582602391835879087,duration=597626704,event=checkout
+[0K$ cd jhlywa/chess.js
+$ git checkout -qf 9b2358fc88800afb03a759c111ed00da4adc265e
+travis_fold:end:git.checkout
+[0K
+travis_time:end:3267c9b9:start=1582602391238252383,finish=1582602391843880664,duration=605628281,event=checkout
+[0Ktravis_time:start:28c1e5da
+[0Ktravis_time:end:28c1e5da:start=1582602391847173736,finish=1582602391853089414,duration=5915678,event=env
+[0Ktravis_fold:start:nvm.install
+[0Ktravis_time:start:0b4b51d1
+[0K$ nvm install node
+Downloading and installing node v13.9.0...
+Downloading https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-x64.tar.xz...
+Computing checksum with sha256sum
+Checksums matched!
+Now using node v13.9.0 (npm v6.13.7)
+travis_time:end:0b4b51d1:start=1582602392557068963,finish=1582602397140290291,duration=4583221328,event=setup
+[0Ktravis_fold:end:nvm.install
+[0K
+travis_fold:start:cache.1
+[0KSetting up build cache
+$ export CASHER_DIR=${TRAVIS_HOME}/.casher
+travis_time:start:0cc18fcb
+[0K$ Installing caching utilities
+travis_time:end:0cc18fcb:start=1582602398322054417,finish=1582602398505374746,duration=183320329,event=setup_casher
+[0Ktravis_time:start:14c7b532
+[0Ktravis_time:end:14c7b532:start=1582602398510124630,finish=1582602398512895392,duration=2770762,event=setup_casher
+[0Ktravis_time:start:0acda6cc
+[0Kattempting to download cache archive[0m
+[32;1mfetching typescript/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
+[32;1mfetching typescript/cache-linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
+[32;1mfetching typescript/cache--node-node.tgz[0m
+[32;1mfetching master/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
+[32;1mfound cache[0m
+travis_time:end:0acda6cc:start=1582602398516601371,finish=1582602400991860225,duration=2475258854,event=setup_casher
+[0Ktravis_fold:end:cache.1
+[0K
+travis_fold:start:cache.npm
+[0K
+travis_time:start:04beaa72
+[0Ktravis_time:end:04beaa72:start=1582602401169066674,finish=1582602401171893545,duration=2826871,event=setup_cache
+[0Ktravis_time:start:08591cf0
+[0Kadding /home/travis/build/jhlywa/chess.js/node_modules to cache[0m
+creating directory /home/travis/build/jhlywa/chess.js/node_modules[0m
+travis_time:end:08591cf0:start=1582602401175602296,finish=1582602402778839517,duration=1603237221,event=setup_cache
+[0Ktravis_fold:end:cache.npm
+[0K$ node --version
+v13.9.0
+$ npm --version
+6.13.7
+$ nvm --version
+0.35.2
+$ yarn --version
+1.15.2
+
+travis_fold:start:install
+[0Ktravis_time:start:0bc503f8
+[0K$ yarn --frozen-lockfile
+[2K[1G[1myarn install v1.15.2[22m
+[2K[1G[2m[1/4][22m Resolving packages...
+[1Gâ  [0K[2K[1G[2K[1G[2m[2/4][22m Fetching packages...
+[2K[1G[34minfo[39m fsevents@1.2.11: The platform "linux" is incompatible with this module.
+[2K[1G[34minfo[39m "fsevents@1.2.11" is an optional dependency and failed compatibility check. Excluding it from installation.
+[2K[1G[2m[3/4][22m Linking dependencies...
+[2K[1G[2m[4/4][22m Building fresh packages...
+[2K[1GDone in 12.88s.
+travis_time:end:0bc503f8:start=1582602403356486047,finish=1582602416400974657,duration=13044488610,event=install
+[0Ktravis_fold:end:install
+[0Ktravis_time:start:0286917c
+[0K$ yarn test
+[2K[1G[1myarn run v1.15.2[22m
+[2K[1G[2m$ jest[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1msan.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mmoves.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mput.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mget.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mremove.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mperft.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-checkmate.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mchess.test.ts[22m
+  [1mâ— [22mConsole
+
+    [2mconsole.log[22m [2m__tests__/chess.test.ts:22[22m
+        +------------------------+
+      8 | r  n  b  q  k  b  n  r |
+      7 | p  p  p  p  p  p  p  p |
+      6 | .  .  .  .  .  .  .  . |
+      5 | .  .  .  .  .  .  .  . |
+      4 | .  .  .  .  .  .  .  . |
+      3 | .  .  .  .  .  .  .  . |
+      2 | P  P  P  P  P  P  P  P |
+      1 | R  N  B  Q  K  B  N  R |
+        +------------------------+
+          a  b  c  d  e  f  g  h
+
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-check.test.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-stalemate.ts[22m
+[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mload.test.ts[22m
+[999D[K
+[1mTest Suites: [22m[1m[32m11 passed[39m[22m, 11 total
+[1mTests:       [22m[1m[32m47 passed[39m[22m, 47 total
+[1mSnapshots:   [22m0 total
+[1mTime:[22m        4.996s
+[2mRan all test suites[22m[2m.[22m
+[2K[1GDone in 5.64s.
+travis_time:end:0286917c:start=1582602416420255009,finish=1582602422206780884,duration=5786525875,event=
+[0K[32;1mThe command "yarn test" exited with 0.[0m
+travis_fold:start:cache.2
+[0Kstore build cache
+travis_time:start:051f1e72
+[0Ktravis_time:end:051f1e72:start=1582602422211608804,finish=1582602422214309757,duration=2700953,event=cache
+[0Ktravis_time:start:0470db40
+[0K[32;1mchanges detected (content changed, file is created, or file is deleted):\n/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/index.js
+/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/LICENSE
+/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/package.json
+/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/README.md
+/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/xhtml.js
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.bundle.js
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.min.js
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.min.js.map
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/ajv.d.ts
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/ajv.js
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/compile/formats.js
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/package.json
+/home/travis/build/jhlywa/chess.js/node_modules/ajv/README.md
+/home/travis/build/jhlywa/chess.js/node_modules/ansi-escapes/index.d.ts
+/home/travis/build/jhlywa/chess.js/node_modules/\n...[0m
+[32;1mchanges detected, packing new archive[0m
+[32;1muploading typescript/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
+[32;1mcache uploaded[0m
+travis_time:end:0470db40:start=1582602422218024869,finish=1582602426622615062,duration=4404590193,event=cache
+[0Ktravis_fold:end:cache.2
+[0K
+
+Done. Your build exited with 0.


### PR DESCRIPTION
travis_fold:start:worker_info
[0K[33;1mWorker information[0m
hostname: f4c42282-3701-409e-8ac9-da7cd8782ddd@1.worker-org-676f4fdd9b-pb25b.gce-production-2
version: v6.2.8 https://github.com/travis-ci/worker/tree/6d3048d96b26562be21fa1a8b8144f4c4cecd083
instance: travis-job-4fab389b-f96a-4057-8730-5eea861a89c5 travis-ci-sardonyx-xenial-1553530528-f909ac5 (via amqp)
startup: 6.203221808s
travis_fold:end:worker_info
[0Ktravis_time:start:0c642b00
[0Ktravis_time:end:0c642b00:start=1582602377733721654,finish=1582602377887978682,duration=154257028,event=no_world_writable_dirs
[0Ktravis_time:start:061f25f4
[0Ktravis_time:end:061f25f4:start=1582602377891558286,finish=1582602377899751147,duration=8192861,event=agent
[0Ktravis_time:start:2c4c2fa9
[0Ktravis_time:end:2c4c2fa9:start=1582602377902946565,finish=1582602377905210699,duration=2264134,event=check_unsupported
[0Ktravis_time:start:0b9d12ea
[0Ktravis_fold:start:system_info
[0K[33;1mBuild system information[0m
Build language: node_js
Build group: stable
Build dist: xenial
Build id: 654724633
Job id: 654724634
Runtime kernel version: 4.15.0-1028-gcp
travis-build version: ad8144f58
[34m[1mBuild image provisioning date and time[0m
Mon Mar 25 16:43:24 UTC 2019
[34m[1mOperating System Details[0m
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.6 LTS
Release:	16.04
Codename:	xenial
[34m[1mSystemd Version[0m
systemd 229
[34m[1mCookbooks Version[0m
42e42e4 https://github.com/travis-ci/travis-cookbooks/tree/42e42e4
[34m[1mgit version[0m
git version 2.21.0
[34m[1mbash version[0m
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
[34m[1mgcc version[0m
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
[34m[1mdocker version[0m
Client:
 Version:           18.06.0-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        0ffa825
 Built:             Wed Jul 18 19:11:02 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.0-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       0ffa825
  Built:            Wed Jul 18 19:09:05 2018
  OS/Arch:          linux/amd64
  Experimental:     false
[34m[1mclang version[0m
clang version 7.0.0 (tags/RELEASE_700/final)
[34m[1mjq version[0m
jq-1.5
[34m[1mbats version[0m
Bats 0.4.0
[34m[1mshellcheck version[0m
0.6.0
[34m[1mshfmt version[0m
v2.6.3
[34m[1mccache version[0m
3.2.4
[34m[1mcmake version[0m
cmake version 3.12.4
[34m[1mheroku version[0m
heroku/7.22.7 linux-x64 node-v11.10.1
[34m[1mimagemagick version[0m
Version: ImageMagick 6.8.9-9 Q16 x86_64 2018-09-28 http://www.imagemagick.org
[34m[1mmd5deep version[0m
4.4
[34m[1mmercurial version[0m
version 4.8
[34m[1mmysql version[0m
mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper
[34m[1mopenssl version[0m
OpenSSL 1.0.2g  1 Mar 2016
[34m[1mpacker version[0m
1.3.3
[34m[1mpostgresql client version[0m
psql (PostgreSQL) 10.7 (Ubuntu 10.7-1.pgdg16.04+1)
[34m[1mragel version[0m
Ragel State Machine Compiler version 6.8 Feb 2013
[34m[1msudo version[0m
1.8.16
[34m[1mgzip version[0m
gzip 1.6
[34m[1mzip version[0m
Zip 3.0
[34m[1mvim version[0m
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:44:48)
[34m[1miptables version[0m
iptables v1.6.0
[34m[1mcurl version[0m
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
[34m[1mwget version[0m
GNU Wget 1.17.1 built on linux-gnu.
[34m[1mrsync version[0m
rsync  version 3.1.1  protocol version 31
[34m[1mgimme version[0m
v1.5.3
[34m[1mnvm version[0m
0.34.0
[34m[1mperlbrew version[0m
/home/travis/perl5/perlbrew/bin/perlbrew  - App::perlbrew/0.86
[34m[1mphpenv version[0m
rbenv 1.1.2
[34m[1mrvm version[0m
rvm 1.29.7 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
[34m[1mdefault ruby version[0m
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
[34m[1mCouchDB version[0m
couchdb 1.6.1
[34m[1mElasticSearch version[0m
5.5.0
[34m[1mInstalled Firefox version[0m
firefox 63.0.1
[34m[1mMongoDB version[0m
MongoDB 4.0.7
[34m[1mPhantomJS version[0m
2.1.1
[34m[1mPre-installed PostgreSQL versions[0m
9.4.21
9.5.16
9.6.12
[34m[1mRedis version[0m
redis-server 5.0.4
[34m[1mPre-installed Go versions[0m
1.11.1
[34m[1mmvn version[0m
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z)
[34m[1mgradle version[0m
Gradle 4.10.2!
[34m[1mlein version[0m
Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM
[34m[1mPre-installed Node.js versions[0m
v10.15.3
v11.0.0
v4.9.1
v6.17.0
v8.12.0
v8.15.1
v8.9
[34m[1mphpenv versions[0m
  system
  5.6
  5.6.40
  7.1
  7.1.27
  7.2
* 7.2.15 (set by /home/travis/.phpenv/version)
  hhvm
  hhvm-stable
[34m[1mcomposer --version[0m
Composer version 1.8.4 2019-02-11 10:52:10
[34m[1mPre-installed Ruby versions[0m
ruby-2.3.8
ruby-2.4.5
ruby-2.5.3
travis_fold:end:system_info
[0K
travis_time:end:0b9d12ea:start=1582602377908239175,finish=1582602377916722008,duration=8482833,event=show_system_info
[0Ktravis_time:start:32ccfb00
[0Ktravis_time:end:32ccfb00:start=1582602377920110024,finish=1582602377932191439,duration=12081415,event=rm_riak_source
[0Ktravis_time:start:0605c6d8
[0Ktravis_time:end:0605c6d8:start=1582602377937473008,finish=1582602377944632400,duration=7159392,event=fix_rwky_redis
[0Ktravis_time:start:0af9f344
[0Ktravis_time:end:0af9f344:start=1582602377947973468,finish=1582602378248944212,duration=300970744,event=wait_for_network
[0Ktravis_time:start:0511f09e
[0Ktravis_time:end:0511f09e:start=1582602378252254897,finish=1582602378459575767,duration=207320870,event=update_apt_keys
[0Ktravis_time:start:0c3a71d2
[0Ktravis_time:end:0c3a71d2:start=1582602378462460967,finish=1582602378517080198,duration=54619231,event=fix_hhvm_source
[0Ktravis_time:start:2437fd56
[0Ktravis_time:end:2437fd56:start=1582602378520583698,finish=1582602378523450227,duration=2866529,event=update_mongo_arch
[0Ktravis_time:start:07f27c98
[0Ktravis_time:end:07f27c98:start=1582602378526342780,finish=1582602378567452996,duration=41110216,event=fix_sudo_enabled_trusty
[0Ktravis_time:start:1049cc5d
[0Ktravis_time:end:1049cc5d:start=1582602378570671255,finish=1582602378572965507,duration=2294252,event=update_glibc
[0Ktravis_time:start:15934c60
[0Ktravis_time:end:15934c60:start=1582602378575884738,finish=1582602378583714176,duration=7829438,event=clean_up_path
[0Ktravis_time:start:10f81d70
[0Ktravis_time:end:10f81d70:start=1582602378586627474,finish=1582602378594357444,duration=7729970,event=fix_resolv_conf
[0Ktravis_time:start:16867734
[0Ktravis_time:end:16867734:start=1582602378597227444,finish=1582602378605839434,duration=8611990,event=fix_etc_hosts
[0Ktravis_time:start:2883b6fe
[0Ktravis_time:end:2883b6fe:start=1582602378608706481,finish=1582602378618332200,duration=9625719,event=fix_mvn_settings_xml
[0Ktravis_time:start:0202e1ce
[0Ktravis_time:end:0202e1ce:start=1582602378621366943,finish=1582602378630533960,duration=9167017,event=no_ipv6_localhost
[0Ktravis_time:start:0b171282
[0Ktravis_time:end:0b171282:start=1582602378633505944,finish=1582602378635769112,duration=2263168,event=fix_etc_mavenrc
[0Ktravis_time:start:0c523e78
[0Ktravis_time:end:0c523e78:start=1582602378638594598,finish=1582602378641494951,duration=2900353,event=fix_wwdr_certificate
[0Ktravis_time:start:0de5c3a3
[0Ktravis_time:end:0de5c3a3:start=1582602378644398844,finish=1582602378667133538,duration=22734694,event=put_localhost_first
[0Ktravis_time:start:07abc884
[0Ktravis_time:end:07abc884:start=1582602378670099492,finish=1582602378673182050,duration=3082558,event=home_paths
[0Ktravis_time:start:224fa62e
[0Ktravis_time:end:224fa62e:start=1582602378676272690,finish=1582602378689527103,duration=13254413,event=disable_initramfs
[0Ktravis_time:start:1af9da20
[0Ktravis_time:end:1af9da20:start=1582602378692674433,finish=1582602379005631987,duration=312957554,event=disable_ssh_roaming
[0Ktravis_time:start:03487cc8
[0Ktravis_time:end:03487cc8:start=1582602379008600820,finish=1582602379010698179,duration=2097359,event=debug_tools
[0Ktravis_time:start:0f2f162e
[0Ktravis_time:end:0f2f162e:start=1582602379013526764,finish=1582602379016670409,duration=3143645,event=uninstall_oclint
[0Ktravis_time:start:18cda970
[0Ktravis_time:end:18cda970:start=1582602379019814239,finish=1582602379022720070,duration=2905831,event=rvm_use
[0Ktravis_time:start:05271bd0
[0Ktravis_time:end:05271bd0:start=1582602379025646096,finish=1582602379033399573,duration=7753477,event=rm_etc_boto_cfg
[0Ktravis_time:start:04b87604
[0Ktravis_time:end:04b87604:start=1582602379036553108,finish=1582602379039525192,duration=2972084,event=rm_oraclejdk8_symlink
[0Ktravis_time:start:047a9249
[0Ktravis_time:end:047a9249:start=1582602379042461991,finish=1582602379157804884,duration=115342893,event=enable_i386
[0Ktravis_time:start:0f758e7e
[0Ktravis_time:end:0f758e7e:start=1582602379160876391,finish=1582602379167337155,duration=6460764,event=update_rubygems
[0Ktravis_time:start:23b59e22
[0Ktravis_time:end:23b59e22:start=1582602379170313746,finish=1582602379990692515,duration=820378769,event=ensure_path_components
[0Ktravis_time:start:06f9041a
[0Ktravis_time:end:06f9041a:start=1582602379993993894,finish=1582602379996231026,duration=2237132,event=redefine_curl
[0Ktravis_time:start:0fdd2884
[0Ktravis_time:end:0fdd2884:start=1582602379999080755,finish=1582602380001314659,duration=2233904,event=nonblock_pipe
[0Ktravis_time:start:07ce13e0
[0Ktravis_time:end:07ce13e0:start=1582602380004230784,finish=1582602386036542583,duration=6032311799,event=apt_get_update
[0Ktravis_time:start:090b03c7
[0Ktravis_time:end:090b03c7:start=1582602386040202715,finish=1582602386042472669,duration=2269954,event=deprecate_xcode_64
[0Ktravis_time:start:25910850
[0Ktravis_time:end:25910850:start=1582602386045282804,finish=1582602388606270491,duration=2560987687,event=update_heroku
[0Ktravis_time:start:1acb3f26
[0Ktravis_time:end:1acb3f26:start=1582602388609774837,finish=1582602388612100541,duration=2325704,event=shell_session_update
[0Ktravis_time:start:002a224a
[0Ktravis_fold:start:docker_mtu
[0Ktravis_fold:end:docker_mtu
[0Ktravis_time:end:002a224a:start=1582602388615299458,finish=1582602390873720502,duration=2258421044,event=set_docker_mtu
[0Ktravis_time:start:11040027
[0Ktravis_fold:start:resolvconf
[0Ktravis_fold:end:resolvconf
[0Ktravis_time:end:11040027:start=1582602390879618111,finish=1582602390950635829,duration=71017718,event=resolvconf
[0Ktravis_time:start:0ac5f51c
[0Ktravis_time:end:0ac5f51c:start=1582602390955046230,finish=1582602391114151634,duration=159105404,event=maven_central_mirror
[0Ktravis_time:start:01a828c7
[0Ktravis_time:end:01a828c7:start=1582602391117480449,finish=1582602391224590480,duration=107110031,event=maven_https
[0Ktravis_time:start:162c9e8b
[0Ktravis_time:end:162c9e8b:start=1582602391228807337,finish=1582602391231199258,duration=2391921,event=fix_ps4
[0Ktravis_time:start:2fc1074c
[0K
travis_fold:start:git.checkout
[0Ktravis_time:start:3267c9b9
[0K$ git clone --depth=50 --branch=typescript https://github.com/jhlywa/chess.js.git jhlywa/chess.js
Cloning into 'jhlywa/chess.js'...
remote: Enumerating objects: 357, done.[K
remote: Counting objects:   0% (1/357)[K
remote: Counting objects:   1% (4/357)[K
remote: Counting objects:   2% (8/357)[K
remote: Counting objects:   3% (11/357)[K
remote: Counting objects:   4% (15/357)[K
remote: Counting objects:   5% (18/357)[K
remote: Counting objects:   6% (22/357)[K
remote: Counting objects:   7% (25/357)[K
remote: Counting objects:   8% (29/357)[K
remote: Counting objects:   9% (33/357)[K
remote: Counting objects:  10% (36/357)[K
remote: Counting objects:  11% (40/357)[K
remote: Counting objects:  12% (43/357)[K
remote: Counting objects:  13% (47/357)[K
remote: Counting objects:  14% (50/357)[K
remote: Counting objects:  15% (54/357)[K
remote: Counting objects:  16% (58/357)[K
remote: Counting objects:  17% (61/357)[K
remote: Counting objects:  18% (65/357)[K
remote: Counting objects:  19% (68/357)[K
remote: Counting objects:  20% (72/357)[K
remote: Counting objects:  21% (75/357)[K
remote: Counting objects:  22% (79/357)[K
remote: Counting objects:  23% (83/357)[K
remote: Counting objects:  24% (86/357)[K
remote: Counting objects:  25% (90/357)[K
remote: Counting objects:  26% (93/357)[K
remote: Counting objects:  27% (97/357)[K
remote: Counting objects:  28% (100/357)[K
remote: Counting objects:  29% (104/357)[K
remote: Counting objects:  30% (108/357)[K
remote: Counting objects:  31% (111/357)[K
remote: Counting objects:  32% (115/357)[K
remote: Counting objects:  33% (118/357)[K
remote: Counting objects:  34% (122/357)[K
remote: Counting objects:  35% (125/357)[K
remote: Counting objects:  36% (129/357)[K
remote: Counting objects:  37% (133/357)[K
remote: Counting objects:  38% (136/357)[K
remote: Counting objects:  39% (140/357)[K
remote: Counting objects:  40% (143/357)[K
remote: Counting objects:  41% (147/357)[K
remote: Counting objects:  42% (150/357)[K
remote: Counting objects:  43% (154/357)[K
remote: Counting objects:  44% (158/357)[K
remote: Counting objects:  45% (161/357)[K
remote: Counting objects:  46% (165/357)[K
remote: Counting objects:  47% (168/357)[K
remote: Counting objects:  48% (172/357)[K
remote: Counting objects:  49% (175/357)[K
remote: Counting objects:  50% (179/357)[K
remote: Counting objects:  51% (183/357)[K
remote: Counting objects:  52% (186/357)[K
remote: Counting objects:  53% (190/357)[K
remote: Counting objects:  54% (193/357)[K
remote: Counting objects:  55% (197/357)[K
remote: Counting objects:  56% (200/357)[K
remote: Counting objects:  57% (204/357)[K
remote: Counting objects:  58% (208/357)[K
remote: Counting objects:  59% (211/357)[K
remote: Counting objects:  60% (215/357)[K
remote: Counting objects:  61% (218/357)[K
remote: Counting objects:  62% (222/357)[K
remote: Counting objects:  63% (225/357)[K
remote: Counting objects:  64% (229/357)[K
remote: Counting objects:  65% (233/357)[K
remote: Counting objects:  66% (236/357)[K
remote: Counting objects:  67% (240/357)[K
remote: Counting objects:  68% (243/357)[K
remote: Counting objects:  69% (247/357)[K
remote: Counting objects:  70% (250/357)[K
remote: Counting objects:  71% (254/357)[K
remote: Counting objects:  72% (258/357)[K
remote: Counting objects:  73% (261/357)[K
remote: Counting objects:  74% (265/357)[K
remote: Counting objects:  75% (268/357)[K
remote: Counting objects:  76% (272/357)[K
remote: Counting objects:  77% (275/357)[K
remote: Counting objects:  78% (279/357)[K
remote: Counting objects:  79% (283/357)[K
remote: Counting objects:  80% (286/357)[K
remote: Counting objects:  81% (290/357)[K
remote: Counting objects:  82% (293/357)[K
remote: Counting objects:  83% (297/357)[K
remote: Counting objects:  84% (300/357)[K
remote: Counting objects:  85% (304/357)[K
remote: Counting objects:  86% (308/357)[K
remote: Counting objects:  87% (311/357)[K
remote: Counting objects:  88% (315/357)[K
remote: Counting objects:  89% (318/357)[K
remote: Counting objects:  90% (322/357)[K
remote: Counting objects:  91% (325/357)[K
remote: Counting objects:  92% (329/357)[K
remote: Counting objects:  93% (333/357)[K
remote: Counting objects:  94% (336/357)[K
remote: Counting objects:  95% (340/357)[K
remote: Counting objects:  96% (343/357)[K
remote: Counting objects:  97% (347/357)[K
remote: Counting objects:  98% (350/357)[K
remote: Counting objects:  99% (354/357)[K
remote: Counting objects: 100% (357/357)[K
remote: Counting objects: 100% (357/357), done.[K
remote: Compressing objects:   0% (1/166)[K
remote: Compressing objects:   1% (2/166)[K
remote: Compressing objects:   2% (4/166)[K
remote: Compressing objects:   3% (5/166)[K
remote: Compressing objects:   4% (7/166)[K
remote: Compressing objects:   5% (9/166)[K
remote: Compressing objects:   6% (10/166)[K
remote: Compressing objects:   7% (12/166)[K
remote: Compressing objects:   8% (14/166)[K
remote: Compressing objects:   9% (15/166)[K
remote: Compressing objects:  10% (17/166)[K
remote: Compressing objects:  11% (19/166)[K
remote: Compressing objects:  12% (20/166)[K
remote: Compressing objects:  13% (22/166)[K
remote: Compressing objects:  14% (24/166)[K
remote: Compressing objects:  15% (25/166)[K
remote: Compressing objects:  16% (27/166)[K
remote: Compressing objects:  17% (29/166)[K
remote: Compressing objects:  18% (30/166)[K
remote: Compressing objects:  19% (32/166)[K
remote: Compressing objects:  20% (34/166)[K
remote: Compressing objects:  21% (35/166)[K
remote: Compressing objects:  22% (37/166)[K
remote: Compressing objects:  23% (39/166)[K
remote: Compressing objects:  24% (40/166)[K
remote: Compressing objects:  25% (42/166)[K
remote: Compressing objects:  26% (44/166)[K
remote: Compressing objects:  27% (45/166)[K
remote: Compressing objects:  28% (47/166)[K
remote: Compressing objects:  29% (49/166)[K
remote: Compressing objects:  30% (50/166)[K
remote: Compressing objects:  31% (52/166)[K
remote: Compressing objects:  32% (54/166)[K
remote: Compressing objects:  33% (55/166)[K
remote: Compressing objects:  34% (57/166)[K
remote: Compressing objects:  35% (59/166)[K
remote: Compressing objects:  36% (60/166)[K
remote: Compressing objects:  37% (62/166)[K
remote: Compressing objects:  38% (64/166)[K
remote: Compressing objects:  39% (65/166)[K
remote: Compressing objects:  40% (67/166)[K
remote: Compressing objects:  41% (69/166)[K
remote: Compressing objects:  42% (70/166)[K
remote: Compressing objects:  43% (72/166)[K
remote: Compressing objects:  44% (74/166)[K
remote: Compressing objects:  45% (75/166)[K
remote: Compressing objects:  46% (77/166)[K
remote: Compressing objects:  47% (79/166)[K
remote: Compressing objects:  48% (80/166)[K
remote: Compressing objects:  49% (82/166)[K
remote: Compressing objects:  50% (83/166)[K
remote: Compressing objects:  51% (85/166)[K
remote: Compressing objects:  52% (87/166)[K
remote: Compressing objects:  53% (88/166)[K
remote: Compressing objects:  54% (90/166)[K
remote: Compressing objects:  55% (92/166)[K
remote: Compressing objects:  56% (93/166)[K
remote: Compressing objects:  57% (95/166)[K
remote: Compressing objects:  58% (97/166)[K
remote: Compressing objects:  59% (98/166)[K
remote: Compressing objects:  60% (100/166)[K
remote: Compressing objects:  61% (102/166)[K
remote: Compressing objects:  62% (103/166)[K
remote: Compressing objects:  63% (105/166)[K
remote: Compressing objects:  64% (107/166)[K
remote: Compressing objects:  65% (108/166)[K
remote: Compressing objects:  66% (110/166)[K
remote: Compressing objects:  67% (112/166)[K
remote: Compressing objects:  68% (113/166)[K
remote: Compressing objects:  69% (115/166)[K
remote: Compressing objects:  70% (117/166)[K
remote: Compressing objects:  71% (118/166)[K
remote: Compressing objects:  72% (120/166)[K
remote: Compressing objects:  73% (122/166)[K
remote: Compressing objects:  74% (123/166)[K
remote: Compressing objects:  75% (125/166)[K
remote: Compressing objects:  76% (127/166)[K
remote: Compressing objects:  77% (128/166)[K
remote: Compressing objects:  78% (130/166)[K
remote: Compressing objects:  79% (132/166)[K
remote: Compressing objects:  80% (133/166)[K
remote: Compressing objects:  81% (135/166)[K
remote: Compressing objects:  82% (137/166)[K
remote: Compressing objects:  83% (138/166)[K
remote: Compressing objects:  84% (140/166)[K
remote: Compressing objects:  85% (142/166)[K
remote: Compressing objects:  86% (143/166)[K
remote: Compressing objects:  87% (145/166)[K
remote: Compressing objects:  88% (147/166)[K
remote: Compressing objects:  89% (148/166)[K
remote: Compressing objects:  90% (150/166)[K
remote: Compressing objects:  91% (152/166)[K
remote: Compressing objects:  92% (153/166)[K
remote: Compressing objects:  93% (155/166)[K
remote: Compressing objects:  94% (157/166)[K
remote: Compressing objects:  95% (158/166)[K
remote: Compressing objects:  96% (160/166)[K
remote: Compressing objects:  97% (162/166)[K
remote: Compressing objects:  98% (163/166)[K
remote: Compressing objects:  99% (165/166)[K
remote: Compressing objects: 100% (166/166)[K
remote: Compressing objects: 100% (166/166), done.[K
Receiving objects:   0% (1/357)   
Receiving objects:   1% (4/357)   
Receiving objects:   2% (8/357)   
Receiving objects:   3% (11/357)   
Receiving objects:   4% (15/357)   
Receiving objects:   5% (18/357)   
Receiving objects:   6% (22/357)   
Receiving objects:   7% (25/357)   
Receiving objects:   8% (29/357)   
Receiving objects:   9% (33/357)   
Receiving objects:  10% (36/357)   
Receiving objects:  11% (40/357)   
Receiving objects:  12% (43/357)   
Receiving objects:  13% (47/357)   
Receiving objects:  14% (50/357)   
Receiving objects:  15% (54/357)   
Receiving objects:  16% (58/357)   
Receiving objects:  17% (61/357)   
Receiving objects:  18% (65/357)   
Receiving objects:  19% (68/357)   
Receiving objects:  20% (72/357)   
Receiving objects:  21% (75/357)   
Receiving objects:  22% (79/357)   
Receiving objects:  23% (83/357)   
Receiving objects:  24% (86/357)   
Receiving objects:  25% (90/357)   
Receiving objects:  26% (93/357)   
Receiving objects:  27% (97/357)   
Receiving objects:  28% (100/357)   
Receiving objects:  29% (104/357)   
Receiving objects:  30% (108/357)   
Receiving objects:  31% (111/357)   
Receiving objects:  32% (115/357)   
Receiving objects:  33% (118/357)   
Receiving objects:  34% (122/357)   
Receiving objects:  35% (125/357)   
Receiving objects:  36% (129/357)   
Receiving objects:  37% (133/357)   
Receiving objects:  38% (136/357)   
Receiving objects:  39% (140/357)   
Receiving objects:  40% (143/357)   
Receiving objects:  41% (147/357)   
Receiving objects:  42% (150/357)   
Receiving objects:  43% (154/357)   
Receiving objects:  44% (158/357)   
Receiving objects:  45% (161/357)   
Receiving objects:  46% (165/357)   
Receiving objects:  47% (168/357)   
Receiving objects:  48% (172/357)   
Receiving objects:  49% (175/357)   
Receiving objects:  50% (179/357)   
Receiving objects:  51% (183/357)   
Receiving objects:  52% (186/357)   
Receiving objects:  53% (190/357)   
Receiving objects:  54% (193/357)   
Receiving objects:  55% (197/357)   
Receiving objects:  56% (200/357)   
Receiving objects:  57% (204/357)   
Receiving objects:  58% (208/357)   
Receiving objects:  59% (211/357)   
Receiving objects:  60% (215/357)   
Receiving objects:  61% (218/357)   
Receiving objects:  62% (222/357)   
Receiving objects:  63% (225/357)   
Receiving objects:  64% (229/357)   
Receiving objects:  65% (233/357)   
Receiving objects:  66% (236/357)   
Receiving objects:  67% (240/357)   
Receiving objects:  68% (243/357)   
Receiving objects:  69% (247/357)   
Receiving objects:  70% (250/357)   
Receiving objects:  71% (254/357)   
Receiving objects:  72% (258/357)   
Receiving objects:  73% (261/357)   
Receiving objects:  74% (265/357)   
Receiving objects:  75% (268/357)   
Receiving objects:  76% (272/357)   
Receiving objects:  77% (275/357)   
Receiving objects:  78% (279/357)   
Receiving objects:  79% (283/357)   
Receiving objects:  80% (286/357)   
Receiving objects:  81% (290/357)   
remote: Total 357 (delta 192), reused 319 (delta 157), pack-reused 0[K
Receiving objects:  82% (293/357)   
Receiving objects:  83% (297/357)   
Receiving objects:  84% (300/357)   
Receiving objects:  85% (304/357)   
Receiving objects:  86% (308/357)   
Receiving objects:  87% (311/357)   
Receiving objects:  88% (315/357)   
Receiving objects:  89% (318/357)   
Receiving objects:  90% (322/357)   
Receiving objects:  91% (325/357)   
Receiving objects:  92% (329/357)   
Receiving objects:  93% (333/357)   
Receiving objects:  94% (336/357)   
Receiving objects:  95% (340/357)   
Receiving objects:  96% (343/357)   
Receiving objects:  97% (347/357)   
Receiving objects:  98% (350/357)   
Receiving objects:  99% (354/357)   
Receiving objects: 100% (357/357)   
Receiving objects: 100% (357/357), 232.81 KiB | 7.05 MiB/s, done.
Resolving deltas:   0% (0/192)   
Resolving deltas:   1% (2/192)   
Resolving deltas:   2% (4/192)   
Resolving deltas:   6% (12/192)   
Resolving deltas:  10% (21/192)   
Resolving deltas:  17% (34/192)   
Resolving deltas:  18% (35/192)   
Resolving deltas:  26% (50/192)   
Resolving deltas:  39% (76/192)   
Resolving deltas:  40% (78/192)   
Resolving deltas:  41% (79/192)   
Resolving deltas:  52% (100/192)   
Resolving deltas:  57% (110/192)   
Resolving deltas:  75% (144/192)   
Resolving deltas:  82% (158/192)   
Resolving deltas:  95% (184/192)   
Resolving deltas: 100% (192/192)   
Resolving deltas: 100% (192/192), done.
travis_time:end:3267c9b9:start=1582602391238252383,finish=1582602391835879087,duration=597626704,event=checkout
[0K$ cd jhlywa/chess.js
$ git checkout -qf 9b2358fc88800afb03a759c111ed00da4adc265e
travis_fold:end:git.checkout
[0K
travis_time:end:3267c9b9:start=1582602391238252383,finish=1582602391843880664,duration=605628281,event=checkout
[0Ktravis_time:start:28c1e5da
[0Ktravis_time:end:28c1e5da:start=1582602391847173736,finish=1582602391853089414,duration=5915678,event=env
[0Ktravis_fold:start:nvm.install
[0Ktravis_time:start:0b4b51d1
[0K$ nvm install node
Downloading and installing node v13.9.0...
Downloading https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-x64.tar.xz...
Computing checksum with sha256sum
Checksums matched!
Now using node v13.9.0 (npm v6.13.7)
travis_time:end:0b4b51d1:start=1582602392557068963,finish=1582602397140290291,duration=4583221328,event=setup
[0Ktravis_fold:end:nvm.install
[0K
travis_fold:start:cache.1
[0KSetting up build cache
$ export CASHER_DIR=${TRAVIS_HOME}/.casher
travis_time:start:0cc18fcb
[0K$ Installing caching utilities
travis_time:end:0cc18fcb:start=1582602398322054417,finish=1582602398505374746,duration=183320329,event=setup_casher
[0Ktravis_time:start:14c7b532
[0Ktravis_time:end:14c7b532:start=1582602398510124630,finish=1582602398512895392,duration=2770762,event=setup_casher
[0Ktravis_time:start:0acda6cc
[0Kattempting to download cache archive[0m
[32;1mfetching typescript/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
[32;1mfetching typescript/cache-linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
[32;1mfetching typescript/cache--node-node.tgz[0m
[32;1mfetching master/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
[32;1mfound cache[0m
travis_time:end:0acda6cc:start=1582602398516601371,finish=1582602400991860225,duration=2475258854,event=setup_casher
[0Ktravis_fold:end:cache.1
[0K
travis_fold:start:cache.npm
[0K
travis_time:start:04beaa72
[0Ktravis_time:end:04beaa72:start=1582602401169066674,finish=1582602401171893545,duration=2826871,event=setup_cache
[0Ktravis_time:start:08591cf0
[0Kadding /home/travis/build/jhlywa/chess.js/node_modules to cache[0m
creating directory /home/travis/build/jhlywa/chess.js/node_modules[0m
travis_time:end:08591cf0:start=1582602401175602296,finish=1582602402778839517,duration=1603237221,event=setup_cache
[0Ktravis_fold:end:cache.npm
[0K$ node --version
v13.9.0
$ npm --version
6.13.7
$ nvm --version
0.35.2
$ yarn --version
1.15.2

travis_fold:start:install
[0Ktravis_time:start:0bc503f8
[0K$ yarn --frozen-lockfile
[2K[1G[1myarn install v1.15.2[22m
[2K[1G[2m[1/4][22m Resolving packages...
[1Gâ  [0K[2K[1G[2K[1G[2m[2/4][22m Fetching packages...
[2K[1G[34minfo[39m fsevents@1.2.11: The platform "linux" is incompatible with this module.
[2K[1G[34minfo[39m "fsevents@1.2.11" is an optional dependency and failed compatibility check. Excluding it from installation.
[2K[1G[2m[3/4][22m Linking dependencies...
[2K[1G[2m[4/4][22m Building fresh packages...
[2K[1GDone in 12.88s.
travis_time:end:0bc503f8:start=1582602403356486047,finish=1582602416400974657,duration=13044488610,event=install
[0Ktravis_fold:end:install
[0Ktravis_time:start:0286917c
[0K$ yarn test
[2K[1G[1myarn run v1.15.2[22m
[2K[1G[2m$ jest[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1msan.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mmoves.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mput.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mget.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mremove.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mperft.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-checkmate.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mchess.test.ts[22m
  [1mâ— [22mConsole

    [2mconsole.log[22m [2m__tests__/chess.test.ts:22[22m
        +------------------------+
      8 | r  n  b  q  k  b  n  r |
      7 | p  p  p  p  p  p  p  p |
      6 | .  .  .  .  .  .  .  . |
      5 | .  .  .  .  .  .  .  . |
      4 | .  .  .  .  .  .  .  . |
      3 | .  .  .  .  .  .  .  . |
      2 | P  P  P  P  P  P  P  P |
      1 | R  N  B  Q  K  B  N  R |
        +------------------------+
          a  b  c  d  e  f  g  h

[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-check.test.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1min-stalemate.ts[22m
[0m[7m[1m[32m PASS [39m[22m[27m[0m [2m__tests__/[22m[1mload.test.ts[22m
[999D[K
[1mTest Suites: [22m[1m[32m11 passed[39m[22m, 11 total
[1mTests:       [22m[1m[32m47 passed[39m[22m, 47 total
[1mSnapshots:   [22m0 total
[1mTime:[22m        4.996s
[2mRan all test suites[22m[2m.[22m
[2K[1GDone in 5.64s.
travis_time:end:0286917c:start=1582602416420255009,finish=1582602422206780884,duration=5786525875,event=
[0K[32;1mThe command "yarn test" exited with 0.[0m
travis_fold:start:cache.2
[0Kstore build cache
travis_time:start:051f1e72
[0Ktravis_time:end:051f1e72:start=1582602422211608804,finish=1582602422214309757,duration=2700953,event=cache
[0Ktravis_time:start:0470db40
[0K[32;1mchanges detected (content changed, file is created, or file is deleted):\n/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/index.js
/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/LICENSE
/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/package.json
/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/README.md
/home/travis/build/jhlywa/chess.js/node_modules/acorn-jsx/xhtml.js
/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.bundle.js
/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.min.js
/home/travis/build/jhlywa/chess.js/node_modules/ajv/dist/ajv.min.js.map
/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/ajv.d.ts
/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/ajv.js
/home/travis/build/jhlywa/chess.js/node_modules/ajv/lib/compile/formats.js
/home/travis/build/jhlywa/chess.js/node_modules/ajv/package.json
/home/travis/build/jhlywa/chess.js/node_modules/ajv/README.md
/home/travis/build/jhlywa/chess.js/node_modules/ansi-escapes/index.d.ts
/home/travis/build/jhlywa/chess.js/node_modules/\n...[0m
[32;1mchanges detected, packing new archive[0m
[32;1muploading typescript/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-node.tgz[0m
[32;1mcache uploaded[0m
travis_time:end:0470db40:start=1582602422218024869,finish=1582602426622615062,duration=4404590193,event=cache
[0Ktravis_fold:end:cache.2
[0K

Done. Your build exited with 0.